### PR TITLE
ENH: Implementing SetPixel/GetPixel for scalar and vector pixel types.

### DIFF
--- a/include/itkTorchImage.h
+++ b/include/itkTorchImage.h
@@ -168,9 +168,26 @@ public:
   void Initialize() override;
 
   /** Fill the torch image buffer with a value.  Be sure to call
+   * Allocate() first. This version is for pixel types that are
+   * simple scalars. */
+  template< typename T = void >
+  typename std::enable_if< PixelDimension == 0, T >::type
+  FillBuffer( const PixelType &value )
+    {
+    m_Tensor.fill_( value );
+    }
+
+  /** Fill the torch image buffer with a value.  Be sure to call
    * Allocate() first. This version is for pixel types that are not
    * simple scalars. */
-  void FillBuffer( const PixelType &value );
+  template< typename T = void >
+  typename std::enable_if< PixelDimension != 0, T >::type
+  FillBuffer( const PixelType &value )
+    {
+    const SizeType &bufferSize = Self::GetBufferedRegion().GetSize();
+    std::vector< at::indexing::TensorIndex > TorchIndex;
+    FillBufferPart( Self::ImageDimension, bufferSize, TorchIndex, value );
+    }
 
   /** \brief Set a pixel value.
    *
@@ -232,7 +249,7 @@ protected:
   void Graft( const DataObject * data ) override;
 
   /** Recursively fill part of the full buffer */
-  void FillBufferPart( int CurrentDimensions, const SizeType &BufferSize, std::vector< int64_t > &TorchIndex, const PixelType &value );
+  void FillBufferPart( int CurrentDimensions, const SizeType &BufferSize, std::vector< at::indexing::TensorIndex > &TorchIndex, const PixelType &value );
 
   /** The enum representation of the data type in the underlying torch
    * library. */

--- a/include/itkTorchImage.hxx
+++ b/include/itkTorchImage.hxx
@@ -171,24 +171,7 @@ TorchImage< TPixel, VImageDimension >
 template< typename TPixel, unsigned int VImageDimension >
 void
 TorchImage< TPixel, VImageDimension >
-::FillBuffer( const PixelType &value )
-{
-  if /* constexpr */ ( PixelDimension == 0 )
-    {
-    m_Tensor.fill_( value );
-    }
-  else
-    {
-    const SizeType &bufferSize = Self::GetBufferedRegion().GetSize();
-    std::vector< int64_t > TorchIndex;
-    FillBufferPart( Self::ImageDimension, bufferSize, TorchIndex, value );
-    }
-}
-
-template< typename TPixel, unsigned int VImageDimension >
-void
-TorchImage< TPixel, VImageDimension >
-::FillBufferPart( int CurrentDimensions, const SizeType &BufferSize, std::vector< int64_t > &TorchIndex, const PixelType &value )
+::FillBufferPart( int CurrentDimensions, const SizeType &BufferSize, std::vector< at::indexing::TensorIndex > &TorchIndex, const PixelType &value )
 {
   if( CurrentDimensions == 0 )
     {
@@ -199,7 +182,7 @@ TorchImage< TPixel, VImageDimension >
     // Slowest varying dimension in BufferSize is last
     for( SizeValueType i = 0; i < BufferSize[CurrentDimensions-1]; ++i )
       {
-      TorchIndex.push_back( i );
+      TorchIndex.push_back( static_cast< int64_t >( i ) );
       FillBufferPart( CurrentDimensions-1, BufferSize, TorchIndex, value );
       TorchIndex.pop_back();
       }
@@ -219,10 +202,10 @@ typename TorchImage< TPixel, VImageDimension >::TorchImagePixelHelper
 TorchImage< TPixel, VImageDimension >
 ::GetPixel( const IndexType & index )
 {
-  std::vector< int64_t > TorchIndex;
-  for( SizeValueType i = 0; i < Self::ImageDimension; ++i )
+  std::vector< at::indexing::TensorIndex > TorchIndex;
+  for( unsigned int i = 0; i < Self::ImageDimension; ++i )
     {
-    TorchIndex.push_back( index[Self::ImageDimension-1-i] );
+    TorchIndex.push_back( static_cast< int64_t >( index[Self::ImageDimension-1-i] ) );
     }
   return TorchImagePixelHelper { m_Tensor, TorchIndex };
 }
@@ -232,10 +215,10 @@ const typename TorchImage< TPixel, VImageDimension >::TorchImagePixelHelper
 TorchImage< TPixel, VImageDimension >
 ::GetPixel( const IndexType & index ) const
 {
-  std::vector< int64_t > TorchIndex;
-  for( SizeValueType i = 0; i < Self::ImageDimension; ++i )
+  std::vector< at::indexing::TensorIndex > TorchIndex;
+  for( unsigned int i = 0; i < Self::ImageDimension; ++i )
     {
-    TorchIndex.push_back( index[Self::ImageDimension-1-i] );
+    TorchIndex.push_back( static_cast< int64_t >( index[Self::ImageDimension-1-i] ) );
     }
   return TorchImagePixelHelper { m_Tensor, TorchIndex };
 }

--- a/include/itkTorchPixelHelper.hxx
+++ b/include/itkTorchPixelHelper.hxx
@@ -24,12 +24,12 @@ namespace itk
 {
 
 template< typename TPixelType, typename Void >
-constexpr int64_t
+constexpr unsigned int
 TorchPixelHelper< TPixelType, Void >
 ::NumberOfComponents;
 
 template< typename TPixelType, typename Void >
-constexpr int64_t
+constexpr unsigned int
 TorchPixelHelper< TPixelType, Void >
 ::SizeOf;
 

--- a/test/itkTorchImageTest.cxx
+++ b/test/itkTorchImageTest.cxx
@@ -21,6 +21,7 @@
 #include "itkCommand.h"
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
+#include "itkRGBPixel.h"
 
 namespace
 {
@@ -125,42 +126,87 @@ int itkTorchImageTest(int argc, char *argv[])
     ImageType::Pointer image = ImageType::New();
   }
 
-  using PixelType = float;
-  using ImageType = itk::TorchImage< PixelType, 2 >;
-  ImageType::Pointer image = ImageType::New();
+  {
+    using PixelType = float;
+    using ImageType = itk::TorchImage< PixelType, 2 >;
+    ImageType::Pointer image = ImageType::New();
 
-  // Create input image
-  ImageType::SizeType size;
-  const bool response = image->ChangeDevice( ImageType::itkCUDA );
-  itkAssertOrThrowMacro(response, "TorchImage<...>::ChangeDevice failed")
-  size.Fill( 128 );
-  image->SetRegions( size );
-  image->Allocate();
+    // Create input image
+    ImageType::SizeType size;
+    const bool response = image->ChangeDevice( ImageType::itkCUDA );
+    itkAssertOrThrowMacro(response, "TorchImage<float, 2>::ChangeDevice failed")
+      size.Fill( 128 );
+    image->SetRegions( size );
+    image->Allocate();
 
-  const PixelType firstValue = 1.1;
-  const PixelType secondValue = 1.2;
-  image->FillBuffer( firstValue );
-  ImageType::IndexType location0;
-  location0.Fill( 0 );
-  ImageType::IndexType location1;
-  location1.Fill( 1 );
-  PixelType pixelValue;
+    const PixelType firstValue = 1.1;
+    const PixelType secondValue = 1.2;
+    ImageType::IndexType location0;
+    location0.Fill( 0 );
+    ImageType::IndexType location1;
+    location1.Fill( 1 );
+    PixelType pixelValue;
 
-  // TRY_EXPECT_NO_EXCEPTION();
+    // TRY_EXPECT_NO_EXCEPTION();
 
-  // image->SetPixel( location0, firstValue );
-  pixelValue = image->GetPixel( location0 );
-  itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<...>::FillBuffer failed" );
-  image->GetPixel( location0 ) = secondValue;
-  pixelValue = image->GetPixel( location0 );
-  itkAssertOrThrowMacro( pixelValue == secondValue, "TorchImage<...>::GetPixel as lvalue failed" );
-  pixelValue = image->GetPixel( location1 );
-  itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<...>::GetPixel has side effect" );
+    image->FillBuffer( firstValue );
+    pixelValue = image->GetPixel( location0 );
+    itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<float, 2>::FillBuffer failed" );
+    image->GetPixel( location0 ) = secondValue;
+    pixelValue = image->GetPixel( location0 );
+    itkAssertOrThrowMacro( pixelValue == secondValue, "TorchImage<float, 2>::GetPixel as lvalue failed" );
+    pixelValue = image->GetPixel( location1 );
+    itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<float, 2>::GetPixel has side effect" );
 
-  ImageType::Pointer image2 = ImageType::New();
-  image2->SetRegions( size );
-  image2->Allocate();
-  image2->Graft( image );
+    ImageType::Pointer image2 = ImageType::New();
+    image2->SetRegions( size );
+    image2->Allocate();
+    image2->Graft( image );
+  }
+
+  {
+    using PixelType = itk::RGBPixel< unsigned char >;
+    using ImageType = itk::TorchImage< PixelType, 3 >;
+    ImageType::Pointer image = ImageType::New();
+
+    // Create input image
+    ImageType::SizeType size;
+    const bool response = image->ChangeDevice( ImageType::itkCUDA );
+    itkAssertOrThrowMacro(response, "TorchImage<RGBPixel<unsigned char>, 3>::ChangeDevice failed")
+      size.Fill( 20 );
+    image->SetRegions( size );
+    image->Allocate();
+
+    PixelType firstValue;
+    firstValue[0] = 1;
+    firstValue[1] = 2;
+    firstValue[2] = 3;
+    PixelType secondValue;
+    secondValue[0] = 4;
+    secondValue[1] = 5;
+    secondValue[2] = 6;
+    ImageType::IndexType location0;
+    location0.Fill( 0 );
+    ImageType::IndexType location1;
+    location1.Fill( 1 );
+    PixelType pixelValue;
+
+    // TRY_EXPECT_NO_EXCEPTION();
+
+    image->FillBuffer( firstValue );
+    pixelValue = image->GetPixel( location0 );
+    itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<RGBPixel<unsigned char>, 3>::FillBuffer failed" );
+    image->GetPixel( location0 ) = secondValue;
+    pixelValue = image->GetPixel( location0 );
+    itkAssertOrThrowMacro( pixelValue == secondValue, "TorchImage<RGBPixel<unsigned char>, 3>::GetPixel as lvalue failed" );
+    pixelValue = image->GetPixel( location1 );
+    itkAssertOrThrowMacro( pixelValue == firstValue, "TorchImage<RGBPixel<unsigned char>, 3>::GetPixel has side effect" );
+
+    ImageType::Pointer image2 = ImageType::New();
+    image2->SetRegions( size );
+    image2->Allocate();
+    image2->Graft( image );
+  }
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
Because GPU memory is not directly addressable from pointers in C++ code, we have to use an interface, such as CUDA's or Torch's to get at the memory.  We use Torch.  We set a single value in a torch tensor by filling a portion of the tensor that includes only the single pixel:
```
myTensor.index( myTorchIndex ).fill_( myNewValue );
```

To read the one pixel we call:
```
myTensor.index( myTorchIndex ).item< myCPPValueType >();
```
... where `myCPPValueType` is `float`, `double`, `unsigned char`, or cetera, _not_ a Torch `dtype`.