### PR TITLE
ENH: Fixing "import yaml" failure

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -87,6 +87,9 @@ jobs:
         cd ..
         mkdir pytorch-build
         cd pytorch-build
+        python2 -m pip install PyYAML
+        python3 -m pip install PyYAML
+        python -m pip install PyYAML
         cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.pytorch-build-type }} -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install -GNinja ../pytorch
         cmake --build . --target install
 
@@ -96,6 +99,9 @@ jobs:
         cd ..
         mkdir pytorch-build
         cd pytorch-build
+        python2 -m pip install PyYAML
+        python3 -m pip install PyYAML
+        python -m pip install PyYAML
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.pytorch-build-type }} -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install -GNinja ../pytorch
         cmake --build . --target install


### PR DESCRIPTION
Also,
Bug: removing build on Microsoft Windows
WIP: adding python/python2/python3 -m pip install PyYAML in "Build Pytorch" section.