### PR TITLE
BUG: Build from sources

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -75,11 +75,8 @@ jobs:
     - name: Download Pytorch
       run: |
         cd ..
-        git clone https://github.com/pytorch/pytorch.git
+        git clone -b ${{ matrix.pytorch-git-tag }} --recurse-submodule https://github.com/pytorch/pytorch.git
         cd pytorch
-        git checkout ${{ matrix.pytorch-git-tag }}
-        git clean -fdx
-        git submodule update --init --recursive
 
     - name: Build Pytorch
       if: matrix.os != 'windows-2019'


### PR DESCRIPTION
We are at the point that the v1.6.0 `torch` (a.k.a., `libtorch`) sources build on Linux.  However, to do:
1. `torch` does not build on Microsoft Windows.  The C++ compiler gives a non-informative error about the code being too complicated and that we should simplify it.
1. On Linux, `torch` builds to completion, but at the time of compiling `ITKPyTorch` module, it cannot be found.  Finding a correct setting for the `Torch_DIR` variable and/or modifying the generation of the `dashboard.cmake` file might be where the solution lies, but my attempts so far have not been successful.